### PR TITLE
Add missing shipwright header into CLI proposal

### DIFF
--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -1,3 +1,9 @@
+<!--
+Copyright The Shipwright Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ---
 title: CLI
 authors:


### PR DESCRIPTION
This is needed, otherwise tests will never pass.